### PR TITLE
Create a counter that uses Apollo local state link

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "apollo-link": "^1.2.3",
     "apollo-link-error": "^1.1.1",
     "apollo-link-http": "^1.5.5",
+    "apollo-link-state": "^0.4.2",
     "graphql": "^14.0.2",
     "graphql-tag": "^2.10.0",
     "react": "^16.6.1",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import { ApolloProvider } from 'react-apollo'
-import logo from './logo.svg'
 import './App.css'
 import Search from './Search'
 import NotificationBar from './NotificationBar'

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,6 +3,8 @@ import { ApolloProvider } from 'react-apollo'
 import logo from './logo.svg'
 import './App.css'
 import Search from './Search'
+import NotificationBar from './NotificationBar'
+import SendNotification from './SendNotification'
 import apolloClient from './apollo-client-setup'
 
 class App extends Component {
@@ -10,6 +12,8 @@ class App extends Component {
     return (
       <ApolloProvider client={apolloClient}>
         <div className="App">
+          <NotificationBar />
+          <SendNotification />
           <Search />
         </div>
       </ApolloProvider>

--- a/client/src/NotificationBar.jsx
+++ b/client/src/NotificationBar.jsx
@@ -1,5 +1,48 @@
-import React from 'react'
+// import React from 'react'
+// import { Mutation } from 'react-apollo'
+// import gql from 'graphql-tag'
+// import './notification-bar.css'
 
+// const mutation = gql`
+//   mutation countQuery($count: Int) {
+//     count(count: $count) @client {
+//       count
+//     }
+//   }
+// `
+
+// export default () => (
+//   <Mutation mutation={mutation}>
+//     {(count, { data }) => {
+//       console.log(count)
+//       console.log(data)
+//       return <div className="notification-bar" />
+//     }}
+//   </Mutation>
+// )
+
+import React from 'react'
+import { Query } from 'react-apollo'
+import gql from 'graphql-tag'
 import './notification-bar.css'
 
-export default props => <div className="notification-bar">Local state notifications</div>
+const query = gql`
+  query countQuery($count: Int) {
+    count(count: $count) @client {
+      number
+    }
+  }
+`
+
+export default () => (
+  <Query query={query}>
+    {({ data, loading }) => {
+      console.log(data)
+      if (loading) {
+        return <h1>loading...</h1>
+      }
+
+      return <div className="notification-bar">{data.count.number}</div>
+    }}
+  </Query>
+)

--- a/client/src/NotificationBar.jsx
+++ b/client/src/NotificationBar.jsx
@@ -6,14 +6,9 @@ import { COUNT_QUERY } from './graphql-crud/queries'
 
 export default () => (
   <Query query={COUNT_QUERY}>
-    {({ loading, error, data }) => {
-      console.log('notifaction bar data:', data)
+    {({ loading, data }) => {
       if (loading) {
         return <h1>loading...</h1>
-      }
-
-      if (error) {
-        console.log('error: ', error)
       }
 
       return <div className="notification-bar">Count: {data.count}</div>

--- a/client/src/NotificationBar.jsx
+++ b/client/src/NotificationBar.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+import './notification-bar.css'
+
+export default props => <div className="notification-bar">Local state notifications</div>

--- a/client/src/NotificationBar.jsx
+++ b/client/src/NotificationBar.jsx
@@ -1,18 +1,11 @@
 import React from 'react'
 import { Query } from 'react-apollo'
-import gql from 'graphql-tag'
 import './notification-bar.css'
 
-const query = gql`
-  query countQuery($count: Int) {
-    count @client {
-      number
-    }
-  }
-`
+import { COUNT_QUERY } from './graphql-crud/queries'
 
 export default () => (
-  <Query query={query}>
+  <Query query={COUNT_QUERY}>
     {({ loading, error, data }) => {
       console.log('notifaction bar data:', data)
       if (loading) {
@@ -23,7 +16,7 @@ export default () => (
         console.log('error: ', error)
       }
 
-      return <div className="notification-bar">Count: {data.count.number}</div>
+      return <div className="notification-bar">Count: {data.count}</div>
     }}
   </Query>
 )

--- a/client/src/NotificationBar.jsx
+++ b/client/src/NotificationBar.jsx
@@ -1,26 +1,3 @@
-// import React from 'react'
-// import { Mutation } from 'react-apollo'
-// import gql from 'graphql-tag'
-// import './notification-bar.css'
-
-// const mutation = gql`
-//   mutation countQuery($count: Int) {
-//     count(count: $count) @client {
-//       count
-//     }
-//   }
-// `
-
-// export default () => (
-//   <Mutation mutation={mutation}>
-//     {(count, { data }) => {
-//       console.log(count)
-//       console.log(data)
-//       return <div className="notification-bar" />
-//     }}
-//   </Mutation>
-// )
-
 import React from 'react'
 import { Query } from 'react-apollo'
 import gql from 'graphql-tag'
@@ -28,7 +5,7 @@ import './notification-bar.css'
 
 const query = gql`
   query countQuery($count: Int) {
-    count(count: $count) @client {
+    count @client {
       number
     }
   }
@@ -36,13 +13,17 @@ const query = gql`
 
 export default () => (
   <Query query={query}>
-    {({ data, loading }) => {
-      console.log(data)
+    {({ loading, error, data }) => {
+      console.log('notifaction bar data:', data)
       if (loading) {
         return <h1>loading...</h1>
       }
 
-      return <div className="notification-bar">{data.count.number}</div>
+      if (error) {
+        console.log('error: ', error)
+      }
+
+      return <div className="notification-bar">Count: {data.count.number}</div>
     }}
   </Query>
 )

--- a/client/src/Search.jsx
+++ b/client/src/Search.jsx
@@ -38,7 +38,7 @@ export default class Search extends Component {
           }}
         />
         <Query query={query} variables={{ name }}>
-          {({ loading, error, data }) => {
+          {({ loading, data }) => {
             if (loading) {
               return <p>Loading...</p>
             }

--- a/client/src/SendNotification.jsx
+++ b/client/src/SendNotification.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default () => (
+  <div>
+    <p>Send a notification using local state:</p>
+    <button>Say hello</button>
+    <button>Say goodbye</button>
+    <button>Increment counter</button>
+    <button>Decrement counter</button>
+  </div>
+)

--- a/client/src/SendNotification.jsx
+++ b/client/src/SendNotification.jsx
@@ -3,11 +3,15 @@ import { Mutation } from 'react-apollo'
 import gql from 'graphql-tag'
 import './notification-bar.css'
 
-const mutation = gql`
-  mutation countQuery($number: Int) {
-    incrementCount(number: $number) @client {
-      number
-    }
+const INCREMENT_COUNT = gql`
+  mutation {
+    incrementCount @client
+  }
+`
+
+const DECREMENT_COUNT = gql`
+  mutation {
+    decrementCount @client
   }
 `
 
@@ -16,29 +20,37 @@ export default class NotificationBar extends Component {
 
   render() {
     return (
-      <Mutation mutation={mutation}>
-        {(incrementCount, { data }) => {
-          console.log(data)
-          return (
-            <div className="notification-bar">
+      <div className="notification-bar">
+        <p>Send a notification using local state:</p>
+        <Mutation mutation={INCREMENT_COUNT}>
+          {incrementCount => {
+            return (
               <button
                 onClick={() => {
                   incrementCount()
                 }}
               >
-                Do something!
+                Increment counter
               </button>
-              <div>
-                <p>Send a notification using local state:</p>
-                <button>Say hello</button>
-                <button>Say goodbye</button>
-                <button>Increment counter</button>
-                <button>Decrement counter</button>
-              </div>
-            </div>
-          )
-        }}
-      </Mutation>
+            )
+          }}
+        </Mutation>
+        <Mutation mutation={DECREMENT_COUNT}>
+          {decrementCount => {
+            return (
+              <button
+                onClick={() => {
+                  decrementCount()
+                }}
+              >
+                Decrement counter
+              </button>
+            )
+          }}
+        </Mutation>
+        <button>Say hello</button>
+        <button>Say goodbye</button>
+      </div>
     )
   }
 }

--- a/client/src/SendNotification.jsx
+++ b/client/src/SendNotification.jsx
@@ -22,28 +22,12 @@ export default class NotificationBar extends Component {
         <p>🔥🔥 Send a notification using local state: 🔥🔥</p>
         <Mutation mutation={INCREMENT_COUNT}>
           {incrementCount => {
-            return (
-              <button
-                onClick={() => {
-                  incrementCount()
-                }}
-              >
-                Increment counter
-              </button>
-            )
+            return <button onClick={incrementCount}>Increment counter</button>
           }}
         </Mutation>
         <Mutation mutation={DECREMENT_COUNT}>
           {decrementCount => {
-            return (
-              <button
-                onClick={() => {
-                  decrementCount()
-                }}
-              >
-                Decrement counter
-              </button>
-            )
+            return <button onClick={decrementCount}>Decrement counter</button>
           }}
         </Mutation>
       </div>

--- a/client/src/SendNotification.jsx
+++ b/client/src/SendNotification.jsx
@@ -1,11 +1,44 @@
-import React from 'react'
+import React, { Component } from 'react'
+import { Mutation } from 'react-apollo'
+import gql from 'graphql-tag'
+import './notification-bar.css'
 
-export default () => (
-  <div>
-    <p>Send a notification using local state:</p>
-    <button>Say hello</button>
-    <button>Say goodbye</button>
-    <button>Increment counter</button>
-    <button>Decrement counter</button>
-  </div>
-)
+const mutation = gql`
+  mutation countQuery($number: Int) {
+    incrementCount(number: $number) @client {
+      number
+    }
+  }
+`
+
+export default class NotificationBar extends Component {
+  state = {}
+
+  render() {
+    return (
+      <Mutation mutation={mutation}>
+        {(incrementCount, { data }) => {
+          console.log(data)
+          return (
+            <div className="notification-bar">
+              <button
+                onClick={() => {
+                  incrementCount()
+                }}
+              >
+                Do something!
+              </button>
+              <div>
+                <p>Send a notification using local state:</p>
+                <button>Say hello</button>
+                <button>Say goodbye</button>
+                <button>Increment counter</button>
+                <button>Decrement counter</button>
+              </div>
+            </div>
+          )
+        }}
+      </Mutation>
+    )
+  }
+}

--- a/client/src/SendNotification.jsx
+++ b/client/src/SendNotification.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { Mutation } from 'react-apollo'
 import gql from 'graphql-tag'
-import './notification-bar.css'
+import './send-notification-bar.css'
 
 const INCREMENT_COUNT = gql`
   mutation {
@@ -16,12 +16,10 @@ const DECREMENT_COUNT = gql`
 `
 
 export default class NotificationBar extends Component {
-  state = {}
-
   render() {
     return (
-      <div className="notification-bar">
-        <p>Send a notification using local state:</p>
+      <div className="send-notification-bar">
+        <p>🔥🔥 Send a notification using local state: 🔥🔥</p>
         <Mutation mutation={INCREMENT_COUNT}>
           {incrementCount => {
             return (
@@ -48,8 +46,6 @@ export default class NotificationBar extends Component {
             )
           }}
         </Mutation>
-        <button>Say hello</button>
-        <button>Say goodbye</button>
       </div>
     )
   }

--- a/client/src/apollo-client-local-state-setup.js
+++ b/client/src/apollo-client-local-state-setup.js
@@ -1,5 +1,6 @@
 // docs: https://www.apollographql.com/docs/link/links/state.html
 import { withClientState } from 'apollo-link-state'
+import gql from 'graphql-tag'
 
 const typeDefs = `
   type Count {
@@ -18,7 +19,7 @@ const typeDefs = `
 
 const defaults = {
   count: {
-    number: 1,
+    number: 0,
     __typename: 'Count',
   },
 }
@@ -30,25 +31,55 @@ export default cache =>
     defaults,
     resolvers: {
       Mutation: {
-        count: (_, { count = 0 }, { cache }) => {
+        incrementCount: (_, { number }, { cache }) => {
           const data = {
+            number: 1,
             __typename: 'Count',
-            count,
           }
 
-          cache.writeData({ data })
-          return null
+          // cache.writeData({ data })
+          console.log('x cache:', cache.readData())
+          return data
         },
-        // updateNetworkStatus: (_, { isConnected }, { cache }) => {
-        //   const data = {
-        //     networkStatus: {
-        //       __typename: 'NetworkStatus',
-        //       isConnected,
-        //     },
-        //   }
-        //   cache.writeData({ data })
-        //   return null
-        // },
       },
+      // Query: {
+      //   count: () => {
+      //     // const query = gql`
+      //     //   query countQuery($count: Int) {
+      //     //     count(count: $count) @client {
+      //     //       number
+      //     //     }
+      //     //   }
+      //     // `
+      //     // console.log('read data:', cache.readData({ query, variables: { number: 55 } }))
+      //     return {
+      //       number: 3,
+      //       __typename: 'Count',
+      //     }
+      //     // return cache.readData()
+
+      //     // return
+      //   },
+      // },
+      // Mutation: {
+      //   count: (_, { count = 0 }, { cache }) => {
+      //     const data = {
+      //       __typename: 'Count',
+      //       count,
+      //     }
+      //     cache.writeData({ data })
+      //     return null
+      //   },
+      // updateNetworkStatus: (_, { isConnected }, { cache }) => {
+      //   const data = {
+      //     networkStatus: {
+      //       __typename: 'NetworkStatus',
+      //       isConnected,
+      //     },
+      //   }
+      //   cache.writeData({ data })
+      //   return null
+      // },
+      // },
     },
   })

--- a/client/src/apollo-client-local-state-setup.js
+++ b/client/src/apollo-client-local-state-setup.js
@@ -22,10 +22,8 @@ export default withClientState({
       decrementCount: (_, __, { cache }) => {
         let { count } = cache.readQuery({ query: COUNT_QUERY })
         count = count - 1
-
         const data = { count }
         cache.writeQuery({ query: COUNT_QUERY, data })
-
         return data
       },
     },

--- a/client/src/apollo-client-local-state-setup.js
+++ b/client/src/apollo-client-local-state-setup.js
@@ -1,0 +1,30 @@
+// docs: https://www.apollographql.com/docs/link/links/state.html
+import { withClientState } from 'apollo-link-state'
+
+export default cache =>
+  withClientState({
+    cache,
+    resolvers: {
+      Mutation: {
+        count: (_, { count }, { cache }) => {
+          const data = {
+            __typename: 'Count',
+            count,
+          }
+
+          cache.writeData({ data })
+          return null
+        },
+        // updateNetworkStatus: (_, { isConnected }, { cache }) => {
+        //   const data = {
+        //     networkStatus: {
+        //       __typename: 'NetworkStatus',
+        //       isConnected,
+        //     },
+        //   }
+        //   cache.writeData({ data })
+        //   return null
+        // },
+      },
+    },
+  })

--- a/client/src/apollo-client-local-state-setup.js
+++ b/client/src/apollo-client-local-state-setup.js
@@ -2,21 +2,6 @@
 import { withClientState } from 'apollo-link-state'
 import { COUNT_QUERY } from './graphql-crud/queries'
 
-const typeDefs = `
-  type Count {
-    number: Int!
-  }
-
-  type Query {
-    count: Count!
-  }
-
-  type Mutation {
-    incrementCount(): Count
-    decrementCount(): Count
-  }
-`
-
 const defaults = {
   count: 0,
 }
@@ -24,61 +9,27 @@ const defaults = {
 export default cache =>
   withClientState({
     cache,
-    // typeDefs,
     defaults,
     resolvers: {
       Mutation: {
         incrementCount: (_, __, { cache }) => {
           let { count } = cache.readQuery({ query: COUNT_QUERY })
           count = count + 1
-          cache.writeQuery({ query: COUNT_QUERY, data: { count } })
-          return {}
+
+          const data = { count }
+          cache.writeQuery({ query: COUNT_QUERY, data })
+
+          return data
         },
         decrementCount: (_, __, { cache }) => {
           let { count } = cache.readQuery({ query: COUNT_QUERY })
           count = count - 1
-          cache.writeQuery({ query: COUNT_QUERY, data: { count } })
-          return {}
+
+          const data = { count }
+          cache.writeQuery({ query: COUNT_QUERY, data })
+
+          return data
         },
       },
-      // Query: {
-      //   count: () => {
-      //     // const query = gql`
-      //     //   query countQuery($count: Int) {
-      //     //     count(count: $count) @client {
-      //     //       number
-      //     //     }
-      //     //   }
-      //     // `
-      //     // console.log('read data:', cache.readData({ query, variables: { number: 55 } }))
-      //     return {
-      //       number: 3,
-      //       __typename: 'Count',
-      //     }
-      //     // return cache.readData()
-
-      //     // return
-      //   },
-      // },
-      // Mutation: {
-      //   count: (_, { count = 0 }, { cache }) => {
-      //     const data = {
-      //       __typename: 'Count',
-      //       count,
-      //     }
-      //     cache.writeData({ data })
-      //     return null
-      //   },
-      // updateNetworkStatus: (_, { isConnected }, { cache }) => {
-      //   const data = {
-      //     networkStatus: {
-      //       __typename: 'NetworkStatus',
-      //       isConnected,
-      //     },
-      //   }
-      //   cache.writeData({ data })
-      //   return null
-      // },
-      // },
     },
   })

--- a/client/src/apollo-client-local-state-setup.js
+++ b/client/src/apollo-client-local-state-setup.js
@@ -1,6 +1,6 @@
 // docs: https://www.apollographql.com/docs/link/links/state.html
 import { withClientState } from 'apollo-link-state'
-import gql from 'graphql-tag'
+import { COUNT_QUERY } from './graphql-crud/queries'
 
 const typeDefs = `
   type Count {
@@ -12,34 +12,33 @@ const typeDefs = `
   }
 
   type Mutation {
-    incrementCount(number: Int): Count
-    decrementCount(number: Int): Count
+    incrementCount(): Count
+    decrementCount(): Count
   }
 `
 
 const defaults = {
-  count: {
-    number: 0,
-    __typename: 'Count',
-  },
+  count: 0,
 }
 
 export default cache =>
   withClientState({
     cache,
-    typeDefs,
+    // typeDefs,
     defaults,
     resolvers: {
       Mutation: {
-        incrementCount: (_, { number }, { cache }) => {
-          const data = {
-            number: 1,
-            __typename: 'Count',
-          }
-
-          // cache.writeData({ data })
-          console.log('x cache:', cache.readData())
-          return data
+        incrementCount: (_, __, { cache }) => {
+          let { count } = cache.readQuery({ query: COUNT_QUERY })
+          count = count + 1
+          cache.writeQuery({ query: COUNT_QUERY, data: { count } })
+          return {}
+        },
+        decrementCount: (_, __, { cache }) => {
+          let { count } = cache.readQuery({ query: COUNT_QUERY })
+          count = count - 1
+          cache.writeQuery({ query: COUNT_QUERY, data: { count } })
+          return {}
         },
       },
       // Query: {

--- a/client/src/apollo-client-local-state-setup.js
+++ b/client/src/apollo-client-local-state-setup.js
@@ -1,12 +1,36 @@
 // docs: https://www.apollographql.com/docs/link/links/state.html
 import { withClientState } from 'apollo-link-state'
 
+const typeDefs = `
+  type Count {
+    number: Int!
+  }
+
+  type Query {
+    count: Count!
+  }
+
+  type Mutation {
+    incrementCount(number: Int): Count
+    decrementCount(number: Int): Count
+  }
+`
+
+const defaults = {
+  count: {
+    number: 1,
+    __typename: 'Count',
+  },
+}
+
 export default cache =>
   withClientState({
     cache,
+    typeDefs,
+    defaults,
     resolvers: {
       Mutation: {
-        count: (_, { count }, { cache }) => {
+        count: (_, { count = 0 }, { cache }) => {
           const data = {
             __typename: 'Count',
             count,

--- a/client/src/apollo-client-local-state-setup.js
+++ b/client/src/apollo-client-local-state-setup.js
@@ -6,30 +6,28 @@ const defaults = {
   count: 0,
 }
 
-export default cache =>
-  withClientState({
-    cache,
-    defaults,
-    resolvers: {
-      Mutation: {
-        incrementCount: (_, __, { cache }) => {
-          let { count } = cache.readQuery({ query: COUNT_QUERY })
-          count = count + 1
+export default withClientState({
+  defaults,
+  resolvers: {
+    Mutation: {
+      incrementCount: (_, __, { cache }) => {
+        let { count } = cache.readQuery({ query: COUNT_QUERY })
+        count = count + 1
 
-          const data = { count }
-          cache.writeQuery({ query: COUNT_QUERY, data })
+        const data = { count }
+        cache.writeQuery({ query: COUNT_QUERY, data })
 
-          return data
-        },
-        decrementCount: (_, __, { cache }) => {
-          let { count } = cache.readQuery({ query: COUNT_QUERY })
-          count = count - 1
+        return data
+      },
+      decrementCount: (_, __, { cache }) => {
+        let { count } = cache.readQuery({ query: COUNT_QUERY })
+        count = count - 1
 
-          const data = { count }
-          cache.writeQuery({ query: COUNT_QUERY, data })
+        const data = { count }
+        cache.writeQuery({ query: COUNT_QUERY, data })
 
-          return data
-        },
+        return data
       },
     },
-  })
+  },
+})

--- a/client/src/apollo-client-setup.js
+++ b/client/src/apollo-client-setup.js
@@ -9,7 +9,7 @@ const cache = new InMemoryCache()
 
 export default new ApolloClient({
   link: ApolloLink.from([
-    apolloLocalStateSetup(cache),
+    apolloLocalStateSetup,
     onError(({ graphQLErrors, networkError }) => {
       if (graphQLErrors)
         graphQLErrors.map(({ message, locations, path }) =>

--- a/client/src/apollo-client-setup.js
+++ b/client/src/apollo-client-setup.js
@@ -3,9 +3,13 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 import { HttpLink } from 'apollo-link-http'
 import { onError } from 'apollo-link-error'
 import { ApolloLink } from 'apollo-link'
+import apolloLocalState from './apollo-client-local-state-setup'
+
+const cache = new InMemoryCache()
 
 export default new ApolloClient({
   link: ApolloLink.from([
+    apolloLocalState(cache),
     onError(({ graphQLErrors, networkError }) => {
       if (graphQLErrors)
         graphQLErrors.map(({ message, locations, path }) =>
@@ -18,5 +22,5 @@ export default new ApolloClient({
       credentials: 'same-origin',
     }),
   ]),
-  cache: new InMemoryCache(),
+  cache,
 })

--- a/client/src/apollo-client-setup.js
+++ b/client/src/apollo-client-setup.js
@@ -3,13 +3,13 @@ import { InMemoryCache } from 'apollo-cache-inmemory'
 import { HttpLink } from 'apollo-link-http'
 import { onError } from 'apollo-link-error'
 import { ApolloLink } from 'apollo-link'
-import apolloLocalState from './apollo-client-local-state-setup'
+import apolloLocalStateSetup from './apollo-client-local-state-setup'
 
 const cache = new InMemoryCache()
 
 export default new ApolloClient({
   link: ApolloLink.from([
-    apolloLocalState(cache),
+    apolloLocalStateSetup(cache),
     onError(({ graphQLErrors, networkError }) => {
       if (graphQLErrors)
         graphQLErrors.map(({ message, locations, path }) =>

--- a/client/src/graphql-crud/queries.js
+++ b/client/src/graphql-crud/queries.js
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag'
+
+export const COUNT_QUERY = gql`
+  query countQuery($count: Int) {
+    count @client
+  }
+`

--- a/client/src/graphql-crud/queries.js
+++ b/client/src/graphql-crud/queries.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 
 export const COUNT_QUERY = gql`
-  query countQuery($count: Int) {
+  query {
     count @client
   }
 `

--- a/client/src/notification-bar.css
+++ b/client/src/notification-bar.css
@@ -1,6 +1,6 @@
 .notification-bar {
   width: 100%;
-  height: 120px;
+  height: 20px;
   background-color: black;
   color: white;
 }

--- a/client/src/notification-bar.css
+++ b/client/src/notification-bar.css
@@ -1,0 +1,6 @@
+.notification-bar {
+  width: 100%;
+  height: 120px;
+  background-color: black;
+  color: white;
+}

--- a/client/src/send-notification-bar.css
+++ b/client/src/send-notification-bar.css
@@ -1,0 +1,4 @@
+.send-notification-bar {
+  width: 100%;
+  background-color: pink;
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1187,6 +1187,14 @@ apollo-link-http@^1.5.5:
     apollo-link "^1.2.3"
     apollo-link-http-common "^0.2.5"
 
+apollo-link-state@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/apollo-link-state/-/apollo-link-state-0.4.2.tgz#ac00e9be9b0ca89eae0be6ba31fe904b80bbe2e8"
+  integrity sha512-xMPcAfuiPVYXaLwC6oJFIZrKgV3GmdO31Ag2eufRoXpvT0AfJZjdaPB4450Nu9TslHRePN9A3quxNueILlQxlw==
+  dependencies:
+    apollo-utilities "^1.0.8"
+    graphql-anywhere "^4.1.0-alpha.0"
+
 apollo-link@^1.0.0, apollo-link@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.3.tgz#9bd8d5fe1d88d31dc91dae9ecc22474d451fb70d"
@@ -1195,7 +1203,7 @@ apollo-link@^1.0.0, apollo-link@^1.2.3:
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.10"
 
-apollo-utilities@1.0.25, apollo-utilities@^1.0.0, apollo-utilities@^1.0.25:
+apollo-utilities@1.0.25, apollo-utilities@^1.0.0, apollo-utilities@^1.0.25, apollo-utilities@^1.0.8:
   version "1.0.25"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.25.tgz#899b00f5f990fb451675adf84cb3de82eb6372ea"
   integrity sha512-AXvqkhni3Ir1ffm4SA1QzXn8k8I5BBl4PVKEyak734i4jFdp+xgfUyi2VCqF64TJlFTA/B73TRDUvO2D+tKtZg==
@@ -4152,6 +4160,13 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
+
+graphql-anywhere@^4.1.0-alpha.0:
+  version "4.1.22"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.22.tgz#1c831ba3c9e5664a0dd24d10d23a9e9512d92056"
+  integrity sha512-qm2/1cKM8nfotxDhm4J0r1znVlK0Yge/yEKt26EVVBgpIhvxjXYFALCGbr7cvfDlvzal1iSPpaYa+8YTtjsxQA==
+  dependencies:
+    apollo-utilities "^1.0.25"
 
 graphql-tag@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
Adds a counter that can be updated by a sibling component via local state. The local state is changed via Apollo client.

This just demos the use of Apollo Client for handling local state, which allows you to remove Redux from the application.

```jsx
<ApolloProvider client={apolloClient}>
	<div className="App">
		<NotificationBar />
        <SendNotification />
        <Search />
    </div>
</ApolloProvider>
```

![nov-09-2018 13-42-43](https://user-images.githubusercontent.com/5850178/48265814-7012c000-e425-11e8-84ec-aeda1b5caaeb.gif)

